### PR TITLE
Work around for Accept header not working on V2

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -101,7 +101,7 @@ module.exports = class HttpClient {
    * @throws Will throw an error if the HTTP request fails.
    */
   sendApiRequest (method, path, payload) {
-    return this.sendRequest(method, `/api/${path}`, payload)
+    return this.sendRequest(method, `/api/v${this.version}/${path}`, payload)
   }
 
   /**


### PR DESCRIPTION
I tried using the javascript SDK but I kept hitting 404s for the v2 api. It seams the version number that was being set in the request ACCEPT header was being ignored by the server. 

Seemed to work if you added v2 to the path (../api/v2/...)