### PR TITLE
fix: always send content type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.1.11 - 2018-11-23
+
+### Changed
+- Always send the `Content-Type` header
+
 ## 0.1.10 - 2018-10-24
 
 ### Fixed

--- a/lib/http.js
+++ b/lib/http.js
@@ -15,7 +15,7 @@ module.exports = class HttpClient {
 
     this.version = apiVersion
     this.timeout = 60000
-    this.headers = {}
+    this.headers = { 'Content-Type': 'application/json' }
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arkecosystem/client",
   "description": "A JavaScript library to interact with the Ark Blockchain",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "contributors": [
     "Brian Faust <brian@ark.io>",
     "Alex Barnsley <alex@ark.io>",


### PR DESCRIPTION
Core now enforces the content type header to be present and expects to be asked for JSON.