### PR TITLE
docs: use the right CDN URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add @arkecosystem/client
 If you want to use the CDN version:
 
 ```html
-<script src="https://unpkg.com/@arkecosystem/client/dist/bundle.umd.js"></script>
+<script src="https://unpkg.com/@arkecosystem/client/dist/index.umd.js"></script>
 ```
 
 ## Usage

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -11,7 +11,6 @@ const format = (dist) => ({
   filename: path.basename(dist)
 })
 
-// bundle without crypto package
 const browserConfig = {
   entry: resolve(pkg.main),
   target: 'web',


### PR DESCRIPTION
The built files was renamed to reflect that they do not include other non-essential dependencies, such as `@arkecosystem/crypto` that are usually necessary to operate with this library.

This PR documents that on the README, to avoid problems: resolves https://github.com/ArkEcosystem/javascript-client/issues/13