### PR TITLE
docs: update the example to the new repo and make it easier to use

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+yarn.lock

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,14 @@
 ## ArkEcosystem Javascript API Client Examples
 
 ### `send-to-random-wallet`
-This example sends 1 DARK to a random wallet if you've enough balance.
+This example sends 1 DARK to a random wallet if you've enough balance. To do that, this examples makes use of the JavaScript crypto library that it is part of [Core](https://github.com/ArkEcosystem/core/tree/master/packages/crypto).
 
  * To use this example, it's necessary having a devnet wallet with at least 1.1 DARK.
 
-To run it:
+
+To try this example, install the dependencies, and execute the script:
 ```
-cd packages/client/examples
+cd examples
+yarn install
 ARK_CLIENT_EXAMPLE_SENDER="devnet wallet address" ARK_CLIENT_EXAMPLE_PASS="the twelve words that forms the password of the wallet" ./post-transaction.js
 ```

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "ark-client-examples",
+  "version": "1.0.0",
+  "description": "Ark JavaScrip examples",
+  "license": "MIT",
+  "dependencies": {
+    "@arkecosystem/client": "^0.1.16",
+    "@arkecosystem/crypto": "^0.2.5"
+  }
+}

--- a/examples/send-to-random-wallet.js
+++ b/examples/send-to-random-wallet.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-const Client = require('../lib/index')
-const crypto = require('../../crypto/lib/index')
+const Client = require('@arkecosystem/client')
+const crypto = require('@arkecosystem/crypto')
 
 const sendGift = async () => {
   const version = 2


### PR DESCRIPTION
When the project was extracted from the Core repository to this new one, the example was not updated. 

This PR adds a `package.json` that would include dependencies for all the examples to make the setup straightforward.

Resolves #17