### PR TITLE
refactor: isHttps property when finding peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.1.18 - 2019-01-22
+
+### Changed
+- Allow https peer option when finding peers
+
 ## 0.1.17 - 2019-01-16
 
 ### Changed

--- a/__tests__/client.test.js
+++ b/__tests__/client.test.js
@@ -186,6 +186,25 @@ describe('API - Client', () => {
       expect(peerRespond).toHaveBeenCalledTimes(2)
     })
 
+    it('should check https if specified', async () => {
+      const data = {
+        success: true,
+        peers: peers
+      }
+
+      const httpPeer = peers[0]
+      const httpsPeer = { ...peers[1], isHttps: true }
+
+      const httpRespond = jest.fn(() => { return [200, data] })
+      const httpsRespond = jest.fn(() => { return [200, data] })
+      httpMock.onGet(`http://${httpPeer.ip}:${httpPeer.port}/api/peers`).reply(() => (httpRespond()))
+      httpMock.onGet(`https://${httpsPeer.ip}:${httpsPeer.port}/api/peers`).reply(() => (httpsRespond()))
+
+      await Client.findPeers(null, 2, [httpPeer, httpsPeer])
+      expect(httpRespond).toHaveBeenCalledTimes(1)
+      expect(httpsRespond).toHaveBeenCalledTimes(1)
+    })
+
     xdescribe('when a peer is not valid', () => {
       it('tries others', () => {
       })

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,8 @@ module.exports = class ApiClient {
     let checks = 0
     let peers = []
     for (const peer of networkPeers) {
-      const peerUrl = `http://${peer.ip}:${peer.port}`
+      const scheme = peer.isHttps ? 'https://' : 'http://'
+      const peerUrl = `${scheme}${peer.ip}:${peer.port}`
 
       // This method should not crash when a peer fails
       try {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arkecosystem/client",
   "description": "A JavaScript library to interact with the Ark Blockchain",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "contributors": [
     "Brian Faust <brian@ark.io>",
     "Alex Barnsley <alex@ark.io>",


### PR DESCRIPTION
This is used when passing a pre-defined list of peers to the findPeers method. If there's individual peers which are flagged with `isHttps: true`, it will use `https://` for fetching the peer list from that peer instead of `http://`.